### PR TITLE
fix demo when loaded over HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
     <link rel="stylesheet" type="text/css" href="demo/style/index.css" />
     <link rel="stylesheet" type="text/css" href="lib/overhang.css" />
     <link rel="stylesheet" type="text/css" href="demo/style/prism.css" />
-    <script type="text/javascript" src="http://code.jquery.com/jquery-1.12.0.min.js"></script>
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js"></script>
     <script type="text/javascript" src="lib/overhang.min.js"></script>
     <script type="text/javascript" src="demo/js/prism.js"></script>
     <script type="text/javascript" src="demo/js/index.js"></script>


### PR DESCRIPTION
Demo page in the README won't work over HTTPS because some browsers may refuse to load HTTP resources (e.g. Chrome, Safari)

See: https://paulkr.github.io/overhang.js/
