### PR TITLE
Add custom colors possibility via css

### DIFF
--- a/lib/overhang.js
+++ b/lib/overhang.js
@@ -36,6 +36,7 @@ $.fn.overhang = function (arguments) {
     upper        : false,
     easing       : "easeOutBounce",
     html         : false,
+    customColors : false,
     callback     : function () {}
   };
 
@@ -74,9 +75,16 @@ $.fn.overhang = function (arguments) {
     attributes.closeConfirm = true;
   }
 
-  // Style colors
-  $overhang.css("background-color", attributes.primary);
-  $overhang.css("border-bottom", "6px solid " + attributes.accent);
+  if(attributes.customColors === false) {
+    // Style colors
+    $overhang.css("background-color", attributes.primary);
+    $overhang.css("border-bottom", "6px solid " + attributes.accent);
+  }
+  else {
+    $overhang.addClass("overhang-custom-" + attributes.type + "-primary-color");
+    $overhang.addClass("overhang-custom-" + attributes.type + "-border");
+  }
+
 
   // Message
   var $message = $("<span class='overhang-message'></span>");
@@ -102,7 +110,7 @@ $.fn.overhang = function (arguments) {
   // Close button
   if (attributes.closeConfirm) {
     var $close = $("<span class='overhang-close'></span>");
-    $close.css("color", attributes.accent);
+    (attributes.customColors === false) ? $close.css("color", attributes.accent) : $close.addClass("overhang-close-custom-" + attributes.type + "-color");
 
     if (attributes.type !== "confirm") {
       $overhang.append($close);


### PR DESCRIPTION
Love your plugin.

I added to my project, and while the default colors are great, and customization is possible for custom notification types, I'd like to be able to set custom colors for the standard default types. 
